### PR TITLE
Task/fix windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ __pycache__/
 inbox/
 figures/
 deprecated/
-zips/
+zips/*.zip
 all_messages.csv
 all_messages_temp.csv
 testing.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 .vscode/
+.idea/
 .env/
 inbox/
 figures/

--- a/messages_analysis.py
+++ b/messages_analysis.py
@@ -12,7 +12,6 @@ def runFullAnalysis():
     print("Parsing data")
     data = getMessages()
 
-
     print("Generating plots")
     generatePlots(data)
 

--- a/messages_analysis.py
+++ b/messages_analysis.py
@@ -12,6 +12,7 @@ def runFullAnalysis():
     print("Parsing data")
     data = getMessages()
 
+
     print("Generating plots")
     generatePlots(data)
 

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Preparing data file shall not take more than 24h. You will be notified when your
 
 #### Setting up the script
 
-After **cloning** this repository place the downloaded zip in `zips` directory and run:
+After **cloning** this repository place the downloaded zip in `zips` subdirectory, [setup the virtual environment](https://uoa-eresearch.github.io/eresearch-cookbook/recipe/2014/11/26/python-virtual-env/) and run:
 
 ```bash
 pip install -r requirements.txt

--- a/src/plots.py
+++ b/src/plots.py
@@ -62,8 +62,6 @@ def plotActivityOverTime(data: pd.DataFrame, user: str, save_dir: str = None, or
     byDates = noGroup.groupby(
         ["date", "sent_by_user"], as_index=True).agg('count')
 
-    dates = pd.date_range(min(data["date"]), max(data["date"]))
-
     plotting = byDates.reset_index()
 
     plotting["messages_per_day"] = plotting["sender_name"]
@@ -119,8 +117,6 @@ def plotActivityForMostFrequentNonGroupChats(data: pd.DataFrame, chats: int, ord
 
     byDates = onlyChosen.groupby(["date", "chat_with"], as_index=True).agg(
         'count')
-
-    dates = pd.date_range(min(data["date"]), max(data["date"]))
 
     plotting = byDates.reset_index()
 

--- a/src/plots.py
+++ b/src/plots.py
@@ -6,6 +6,7 @@ import os
 import random
 import re
 import numpy as np
+import time
 import math
 
 import matplotlib.pyplot as plt
@@ -58,18 +59,20 @@ def plotActivityOverTime(data: pd.DataFrame, user: str, save_dir: str = None, or
     noGroup["sent_by_user"] = noGroup["sender_name"].apply(
         lambda x: True if x == user else False)
 
-    byDates = noGroup.groupby(["date", "sent_by_user"], as_index=True).agg([
-        'count'])
+    byDates = noGroup.groupby(["date", "sent_by_user"], as_index=True).agg('count')
 
     dates = pd.date_range(min(data["date"]), max(data["date"]))
 
     plotting = byDates.reindex(dates, level=0).reset_index()
 
-    plotting["messages_per_day"] = plotting[("sender_name", "count")]
+    plotting["messages_per_day"] = plotting["sender_name"]
+
+    plotting["datetime"] = plotting["date"].apply(lambda dstr: time.mktime(time.strptime(dstr, "%Y-%m-%d")))
+
+    plotting["date_float"] = plotting["datetime"].values.astype(float)
+
     plotting["Message direction"] = plotting["sent_by_user"].apply(
         lambda x: "Sent" if x else "Received")
-
-    plotting["date_float"] = plotting["date"].values.astype(float)
 
     g = sns.lmplot(data=plotting, x="date_float", y="messages_per_day",
                    hue="Message direction", scatter=False, order=order, legend_out=False, aspect=1.7, palette="Set1")
@@ -120,6 +123,8 @@ def plotActivityForMostFrequentNonGroupChats(data: pd.DataFrame, chats: int, ord
     plotting = byDates.reindex(dates, level=0).reset_index()
 
     plotting["messages_per_day"] = plotting["sender_name"]
+
+    # plotting["datetime"] = plotting["date"].apply(lambda dstr: time.mktime(time.strptime(dstr, "%Y-%m-%d")))
 
     plotting["date_float"] = plotting["date"].values.astype(float)
 

--- a/src/plots.py
+++ b/src/plots.py
@@ -59,15 +59,17 @@ def plotActivityOverTime(data: pd.DataFrame, user: str, save_dir: str = None, or
     noGroup["sent_by_user"] = noGroup["sender_name"].apply(
         lambda x: True if x == user else False)
 
-    byDates = noGroup.groupby(["date", "sent_by_user"], as_index=True).agg('count')
+    byDates = noGroup.groupby(
+        ["date", "sent_by_user"], as_index=True).agg('count')
 
     dates = pd.date_range(min(data["date"]), max(data["date"]))
 
-    plotting = byDates.reindex(dates, level=0).reset_index()
+    plotting = byDates.reset_index()
 
     plotting["messages_per_day"] = plotting["sender_name"]
 
-    plotting["datetime"] = plotting["date"].apply(lambda dstr: time.mktime(time.strptime(dstr, "%Y-%m-%d")))
+    plotting["datetime"] = plotting["date"].astype(str).apply(
+        lambda dstr: time.mktime(time.strptime(dstr, r"%Y-%m-%d")))
 
     plotting["date_float"] = plotting["datetime"].values.astype(float)
 
@@ -120,13 +122,14 @@ def plotActivityForMostFrequentNonGroupChats(data: pd.DataFrame, chats: int, ord
 
     dates = pd.date_range(min(data["date"]), max(data["date"]))
 
-    plotting = byDates.reindex(dates, level=0).reset_index()
+    plotting = byDates.reset_index()
 
     plotting["messages_per_day"] = plotting["sender_name"]
 
-    # plotting["datetime"] = plotting["date"].apply(lambda dstr: time.mktime(time.strptime(dstr, "%Y-%m-%d")))
+    plotting["datetime"] = plotting["date"].astype(str).apply(
+        lambda dstr: time.mktime(time.strptime(dstr, "%Y-%m-%d")))
 
-    plotting["date_float"] = plotting["date"].values.astype(float)
+    plotting["date_float"] = plotting["datetime"].values.astype(float)
 
     cat_type = pd.api.types.CategoricalDtype(categories=names, ordered=True)
 

--- a/src/zip_extraction.py
+++ b/src/zip_extraction.py
@@ -22,6 +22,7 @@ def getZipPath(folderName: str = DEFAULT_ZIP_FOLDER, user: str = USER) -> str:
         if ((fileName.endswith(".zip")) and (str(prepName) in str(fileName))):
             return os.path.join(folderName, fileName)
 
+    print("ERROR: No zip file for user ", USER)
     return None
 
 
@@ -76,7 +77,7 @@ def getDataFrame(folderName: str = DEFAULT_ZIP_FOLDER, user: str = USER, isAnony
 
 def getDates(data: pd.DataFrame, timezone: str = TIMEZONE) -> pd.DataFrame:
     data["date"] = pd.to_datetime(data["timestamp_ms"]*int(
-        1e6)).dt.tz_localize('UTC').dt.tz_convert(timezone).dt.strftime('%Y-%m-%d')
+        1e6), errors="ignore").dt.tz_localize('UTC').dt.tz_convert(timezone).dt.strftime('%Y-%m-%d')
 
     data["weekday"] = pd.to_datetime(data["timestamp_ms"]*int(
         1e6)).dt.tz_localize('UTC').dt.tz_convert(timezone).dt.strftime('%A')
@@ -99,7 +100,8 @@ def getMessages(folderName: str = DEFAULT_ZIP_FOLDER, outputName: str = DEFAULT_
     if isinstance(outputName, str):
         dataFrame.to_csv(outputName, index=False)
 
-    if(timezone != None):
+    if isinstance(timezone, str):
         return getDates(dataFrame, timezone)
     else:
+        print("WARNING: No timezone provided")
         return dataFrame

--- a/zips/readme.md
+++ b/zips/readme.md
@@ -1,0 +1,2 @@
+# Zips folder
+Put your zip files in this directory


### PR DESCRIPTION
Close #10. The problem was that during the index reset pandas automatically turned the `str` to `DateTime` on Linux machines, but not on Windows. Further tests need to be done - especially on **Windows** machines.

Additionally, add minor Error Logs and include the `zips` folder in the repository (to avoid user confusion).